### PR TITLE
Support single-line code blocks

### DIFF
--- a/docs/examples/valid-use.md
+++ b/docs/examples/valid-use.md
@@ -25,6 +25,9 @@ Markdown links within code blocks are ignored so because they would not be click
 [nonexistent](./non.md#existent)
 ```
 
+<!-- prettier-ignore -->
+```also doesn't get confused by exotic formatting like this one```
+
 ## ::nut_and_bolt:: Emojis
 
 [Like the one above](./valid-use.md#nut_and_bolt-emojis)

--- a/internal/markdown/scan/scan.go
+++ b/internal/markdown/scan/scan.go
@@ -110,7 +110,19 @@ func scanFile(file *os.File) (Result, error) {
 func hasCodeBlockMarker(line string) bool {
 	trimmedLine := strings.TrimLeft(line, " \t")
 
-	return strings.HasPrefix(trimmedLine, "```")
+	// Must start with ```
+	if !strings.HasPrefix(trimmedLine, "```") {
+		return false
+	}
+
+	afterMarker := trimmedLine[3:]
+
+	// Ensure code block is not closed on the same line
+	if !strings.Contains(afterMarker, "```") {
+		return true
+	}
+
+	return false
 }
 
 func extractLink(links *[]link.Link, line string, lineNumber int) {


### PR DESCRIPTION
This broke heading detection in some rare cases